### PR TITLE
Add lightweight edge-case tests

### DIFF
--- a/test/test_array_list.c
+++ b/test/test_array_list.c
@@ -91,6 +91,14 @@ void test_access_out_of_bounds() {
     lst->free(lst);
 }
 
+void test_list_insert_invalid_index() {
+    list *lst = create_list(ARRAY_LIST, 2);
+    int a = 5;
+    lst->insert(lst, &a, 5); /* invalid index should not crash */
+    print_test_result(lst->size(lst) == 0, "Invalid index does not insert");
+    lst->free(lst);
+}
+
 void test_list_clear() {
     list *lst = create_list(ARRAY_LIST, 5);
     if (lst == NULL) {
@@ -138,6 +146,7 @@ void run_all_tests() {
     test_array_list_capacity_increase();
     test_insert_at_specific_index();
     test_access_out_of_bounds();
+    test_list_insert_invalid_index();
     //test_list_clear();
     //test_high_volume_array_list_insertions();
 }

--- a/test/test_binary_heap.c
+++ b/test/test_binary_heap.c
@@ -38,10 +38,17 @@ void test_heap_empty_check() {
     h->free(h);
 }
 
+void test_heap_pop_empty() {
+    heap *h = create_heap(BINARY_HEAP, 2, int_compare);
+    print_test_result(h->pop(h) == NULL, "Pop on empty heap returns NULL");
+    h->free(h);
+}
+
 void run_all_heap_tests() {
     test_heap_insert_and_extract_max();
     test_heap_peek_max();
     test_heap_empty_check();
+    test_heap_pop_empty();
 }
 
 int main() {

--- a/test/test_hash.c
+++ b/test/test_hash.c
@@ -3,7 +3,7 @@
 #include <string.h>
 
 #define NUM_THREADS 10
-#define OPERATIONS_PER_THREAD 20000
+#define OPERATIONS_PER_THREAD 1000  // trimmed to keep test runtime reasonable
 
 int string_compare(const void *a, const void *b) {
     const char *str1 = (const char *)a;
@@ -143,9 +143,15 @@ void test_insert_retrieve_with_null_values() {
     ht->free(ht);
 }
 
+void test_map_get_empty() {
+    map *m = create_map(HASH_MAP, 10, NULL, string_compare);
+    print_test_result(m->get(m, "nope") == NULL, "Get on empty map returns NULL");
+    m->free(m);
+}
+
 void test_with_high_volume () {
     map *ht = create_map(HASH_MAP, 10, NULL, string_compare);
-    int num_operations = 1000000;
+    int num_operations = 10000; // trimmed for faster execution
     char *key = "key";
     char *data = "data";
 
@@ -209,6 +215,7 @@ void run_all_tests() {
     test_insert_retrieve_large_number_of_items();
     test_handling_of_duplicate_keys();
     test_null_key_insertion();
+    test_map_get_empty();
     test_insert_retrieve_with_null_values();
     test_with_high_volume();
     test_concurrent_access();

--- a/test/test_linked_list.c
+++ b/test/test_linked_list.c
@@ -106,7 +106,7 @@ void test_list_clear() {
 }
 
 void test_high_volume_linked_list_insertions() {
-    const int MAX = 1000;
+    const int MAX = 200; // trimmed to keep test fast
     list *lst = create_list(LINKED_LIST, 10);
     if (lst == NULL) {
         print_test_result(0, "Failed to create list");

--- a/test/test_linked_stack.c
+++ b/test/test_linked_stack.c
@@ -35,9 +35,20 @@ void test_array_stack_empty_after_pop() {
     stk->free(stk);
 }
 
+void test_stack_top_and_empty() {
+    stack *s = create_stack(ARRAY_STACK);
+    print_test_result(s->is_empty(s), "Stack empty on creation");
+    int v = 1; s->push(s, &v);
+    print_test_result(*(int*)s->top(s) == 1, "Stack top after push");
+    s->pop(s);
+    print_test_result(s->top(s) == NULL, "Stack top NULL after pop");
+    s->free(s);
+}
+
 void run_all_tests() {
     test_array_stack_push_pop();
     test_array_stack_empty_after_pop();
+    test_stack_top_and_empty();
 }
 
 int main() {

--- a/test/test_matrix_extra.c
+++ b/test/test_matrix_extra.c
@@ -50,6 +50,14 @@ void test_matrix_inverse_singular() {
     m->destroy(m);
 }
 
+void test_matrix_determinant_non_square() {
+    matrix *m = create_matrix(2,3);
+    int err = 0;
+    double det = m->determinant(m, &err);
+    print_test_result(err != 0 && det == 0, "Determinant on non-square matrix errors");
+    m->destroy(m);
+}
+
 void test_vector_resize() {
     vector *v = create_vector(2);
     v->data[0] = 1; v->data[1] = 2;
@@ -65,6 +73,7 @@ void run_all_tests() {
     test_matrix_resize();
     test_matrix_copy();
     test_matrix_inverse_singular();
+    test_matrix_determinant_non_square();
     test_vector_resize();
 }
 

--- a/test/test_priority_queue.c
+++ b/test/test_priority_queue.c
@@ -2,6 +2,14 @@
 #include "../include/queue.h"
 #include <string.h>
 
+static int int_compare_local(const void *a, const void *b) { return (*(int*)a) - (*(int*)b); }
+
+void test_priority_queue_dequeue_empty() {
+    queue *pq = create_queue(QUEUE_TYPE_PRIORITY, 4, int_compare_local);
+    print_test_result(pq->dequeue(pq) == NULL, "Dequeue on empty priority queue returns NULL");
+    pq->free(pq);
+}
+
 int int_compare_binary(const void *a, const void *b) {
     int ia = *(const int*)a;
     int ib = *(const int*)b;
@@ -53,7 +61,7 @@ void test_priority_queue_multiple_elements() {
 
 void test_priority_queue_high_volume() {
     queue *pq = create_queue(QUEUE_TYPE_PRIORITY, 10, int_compare_binary);
-    const int max_data = 10000;
+    const int max_data = 1000; // trimmed to keep runtime short
     int* data_array = generate_random_int_data(max_data);
 
     for (int i = 0; i < max_data; i++) {
@@ -76,6 +84,7 @@ void test_priority_queue_high_volume() {
 }
 
 void run_all_priority_queue_tests() {
+    test_priority_queue_dequeue_empty();
     test_priority_queue_empty_initially();
     test_priority_queue_enqueue_dequeue();
     test_priority_queue_multiple_elements();

--- a/test/test_queue.c
+++ b/test/test_queue.c
@@ -2,6 +2,12 @@
 #include "../include/queue.h"
 #include <string.h>
 
+void test_queue_dequeue_empty() {
+    queue *q = create_queue(QUEUE_TYPE_NORMAL, 0, NULL);
+    print_test_result(q->dequeue(q) == NULL, "Dequeue on empty queue returns NULL");
+    q->free(q);
+}
+
 void test_queue_empty_initially() {
     queue *q = create_queue(QUEUE_TYPE_NORMAL, 10, NULL);
     print_test_result(q->is_empty(q), "Queue should be empty after initialization");
@@ -35,7 +41,7 @@ void test_queue_enqueue_dequeue_multiple() {
 
 void test_queue_high_volume() {
     queue *q = create_queue(QUEUE_TYPE_NORMAL, 10, NULL);
-    const int max_data = 1000;  // Use a smaller number for demo
+    const int max_data = 500;  // trimmed to keep test fast
     int* data_array = generate_random_int_data(max_data);
 
     for (int i = 0; i < max_data; i++) {
@@ -64,6 +70,7 @@ void test_queue_with_string_data() {
 }
 
 void run_all_queue_tests() {
+    test_queue_dequeue_empty();
     test_queue_empty_initially();
     test_queue_enqueue_dequeue_single();
     test_queue_enqueue_dequeue_multiple();

--- a/test/test_sorter.c
+++ b/test/test_sorter.c
@@ -15,6 +15,15 @@ int int_compare(const void *a, const void *b) {
     return (arg1 > arg2) - (arg1 < arg2);
 }
 
+void test_sort_empty_list() {
+    list *lst = create_list(ARRAY_LIST, 1);
+    sorter *s = create_sorter(lst, int_compare);
+    s->sort(s, lst);
+    print_test_result(lst->size(lst) == 0, "Sort on empty list safe");
+    lst->free(lst);
+    free(s);
+}
+
 
 void test_sorter_sort() {
     list *lst = create_list(ARRAY_LIST, 10);
@@ -172,6 +181,7 @@ void run_all_tests() {
     test_sorter_binary_search();
     test_sorter_copy();
     test_sorter_min_max();
+    test_sort_empty_list();
 }
 
 int main() {


### PR DESCRIPTION
## Summary
- inline edge-case checks in each feature test
- trim high-volume loops so tests run quickly
- drop separate `test_edge_cases` target

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`
