### PR TITLE
Add more exhaustive tests across structures

### DIFF
--- a/test/test_array_list.c
+++ b/test/test_array_list.c
@@ -58,6 +58,14 @@ void test_array_list_capacity_increase() {
 
     lst->free(lst);
 }
+
+void test_insert_invalid_index() {
+    list *lst = create_list(ARRAY_LIST, 2);
+    int a = 5;
+    lst->insert(lst, &a, 5); /* invalid index should not crash */
+    print_test_result(lst->size(lst) == 0, "Invalid index does not insert");
+    lst->free(lst);
+}
 void test_insert_at_specific_index() {
     list *lst = create_list(ARRAY_LIST, 5);
     int initial_items[] = {10, 20, 40, 50};
@@ -108,7 +116,7 @@ void test_list_clear() {
 }
 
 void test_high_volume_linked_list_insertions() {
-    const int MAX = 1000;
+    const int MAX = 2000;  // larger dataset for coverage
     list *lst = create_list(ARRAY_LIST, 10);
     if (lst == NULL) {
         print_test_result(0, "Failed to create list");
@@ -136,10 +144,10 @@ void run_all_tests() {
     test_array_list_insert_and_get();
     test_array_list_remove();
     test_array_list_capacity_increase();
+    test_insert_invalid_index();
     test_insert_at_specific_index();
     test_access_out_of_bounds();
-    //test_list_clear();
-    //test_high_volume_array_list_insertions();
+    test_high_volume_linked_list_insertions();
 }
 
 int main() {

--- a/test/test_array_stack.c
+++ b/test/test_array_stack.c
@@ -35,9 +35,39 @@ void test_linked_stack_empty_after_pop() {
     stk->free(stk);
 }
 
+void test_stack_top_behavior() {
+    stack *s = create_stack(LINKED_STACK);
+    print_test_result(s->is_empty(s), "Stack empty on creation");
+    int v = 1;
+    s->push(s, &v);
+    print_test_result(*(int*)s->top(s) == 1, "Stack top after push");
+    s->pop(s);
+    print_test_result(s->top(s) == NULL, "Stack top NULL after pop");
+    s->free(s);
+}
+
+void test_stack_high_volume() {
+    stack *s = create_stack(LINKED_STACK);
+    const int max_items = 5000;
+    int *items = generate_random_int_data(max_items);
+    for (int i = 0; i < max_items; i++) {
+        s->push(s, &items[i]);
+    }
+    for (int i = max_items - 1; i >= 0; i--) {
+        int *val = (int *)s->pop(s);
+        assert_not_null(val);
+        assert_int_equal(*val, items[i]);
+    }
+    print_test_result(s->is_empty(s), "Stack empty after high volume pop");
+    free(items);
+    s->free(s);
+}
+
 void run_all_tests() {
     test_linked_stack_push_pop();
     test_linked_stack_empty_after_pop();
+    test_stack_top_behavior();
+    test_stack_high_volume();
 }
 
 int main() {

--- a/test/test_binary_heap.c
+++ b/test/test_binary_heap.c
@@ -38,10 +38,34 @@ void test_heap_empty_check() {
     h->free(h);
 }
 
+void test_heap_pop_empty() {
+    heap *h = create_heap(BINARY_HEAP, 10, int_compare);
+    print_test_result(h->pop(h) == NULL, "Pop on empty heap returns NULL");
+    h->free(h);
+}
+
+void test_heap_high_volume() {
+    heap *h = create_heap(BINARY_HEAP, 10, int_compare);
+    const int max_data = 10000;
+    int *values = generate_random_int_data(max_data);
+    for (int i = 0; i < max_data; i++) {
+        h->put(h, &values[i]);
+    }
+    for (int i = 0; i < max_data; i++) {
+        int *val = (int *)h->pop(h);
+        assert_not_null(val);
+    }
+    print_test_result(h->size(h) == 0, "Heap empty after high volume pop");
+    free(values);
+    h->free(h);
+}
+
 void run_all_heap_tests() {
     test_heap_insert_and_extract_max();
     test_heap_peek_max();
     test_heap_empty_check();
+    test_heap_pop_empty();
+    test_heap_high_volume();
 }
 
 int main() {

--- a/test/test_fibonacci_heap.c
+++ b/test/test_fibonacci_heap.c
@@ -38,10 +38,34 @@ void test_heap_empty_check() {
     h->free(h);
 }
 
+void test_heap_pop_empty() {
+    heap *h = create_heap(FIBONACCI_HEAP, 10, int_compare_fibonacci);
+    print_test_result(h->pop(h) == NULL, "Pop on empty heap returns NULL");
+    h->free(h);
+}
+
+void test_heap_high_volume() {
+    heap *h = create_heap(FIBONACCI_HEAP, 10, int_compare_fibonacci);
+    const int max_data = 10000;
+    int *values = generate_random_int_data(max_data);
+    for (int i = 0; i < max_data; i++) {
+        h->put(h, &values[i]);
+    }
+    for (int i = 0; i < max_data; i++) {
+        int *val = (int *)h->pop(h);
+        assert_not_null(val);
+    }
+    print_test_result(h->size(h) == 0, "Heap empty after high volume pop");
+    free(values);
+    h->free(h);
+}
+
 void run_all_heap_tests() {
     test_heap_insert_and_extract_max();
     test_heap_peek_max();
     test_heap_empty_check();
+    test_heap_pop_empty();
+    test_heap_high_volume();
 }
 
 int main() {

--- a/test/test_linked_list.c
+++ b/test/test_linked_list.c
@@ -58,6 +58,14 @@ void test_linked_list_capacity_increase() {
 
     lst->free(lst);
 }
+
+void test_insert_invalid_index() {
+    list *lst = create_list(LINKED_LIST, 2);
+    int a = 5;
+    lst->insert(lst, &a, 5); /* invalid index should not crash */
+    print_test_result(lst->size(lst) == 0, "Invalid index does not insert");
+    lst->free(lst);
+}
 void test_insert_at_specific_index() {
     list *lst = create_list(LINKED_LIST, 5);
     int initial_items[] = {10, 20, 40, 50};
@@ -106,7 +114,7 @@ void test_list_clear() {
 }
 
 void test_high_volume_linked_list_insertions() {
-    const int MAX = 1000;
+    const int MAX = 2000;
     list *lst = create_list(LINKED_LIST, 10);
     if (lst == NULL) {
         print_test_result(0, "Failed to create list");
@@ -131,6 +139,7 @@ void run_all_tests() {
     test_linked_list_insert_and_get();
     test_linked_list_remove();
     test_linked_list_capacity_increase();
+    test_insert_invalid_index();
     test_insert_at_specific_index();
     test_access_out_of_bounds();
     test_list_clear();

--- a/test/test_linked_stack.c
+++ b/test/test_linked_stack.c
@@ -35,9 +35,39 @@ void test_array_stack_empty_after_pop() {
     stk->free(stk);
 }
 
+void test_stack_top_behavior() {
+    stack *s = create_stack(ARRAY_STACK);
+    print_test_result(s->is_empty(s), "Stack empty on creation");
+    int v = 1;
+    s->push(s, &v);
+    print_test_result(*(int*)s->top(s) == 1, "Stack top after push");
+    s->pop(s);
+    print_test_result(s->top(s) == NULL, "Stack top NULL after pop");
+    s->free(s);
+}
+
+void test_stack_high_volume() {
+    stack *s = create_stack(ARRAY_STACK);
+    const int max_items = 5000;
+    int *items = generate_random_int_data(max_items);
+    for (int i = 0; i < max_items; i++) {
+        s->push(s, &items[i]);
+    }
+    for (int i = max_items - 1; i >= 0; i--) {
+        int *val = (int *)s->pop(s);
+        assert_not_null(val);
+        assert_int_equal(*val, items[i]);
+    }
+    print_test_result(s->is_empty(s), "Stack empty after high volume pop");
+    free(items);
+    s->free(s);
+}
+
 void run_all_tests() {
     test_array_stack_push_pop();
     test_array_stack_empty_after_pop();
+    test_stack_top_behavior();
+    test_stack_high_volume();
 }
 
 int main() {

--- a/test/test_matrix.c
+++ b/test/test_matrix.c
@@ -181,6 +181,23 @@ void test_matrix_inverse() {
     expected->destroy(expected);
 }
 
+void test_matrix_large_multiply() {
+    int size = 20;
+    matrix *m1 = create_matrix(size, size);
+    matrix *m2 = create_matrix(size, size);
+    for (int i = 0; i < size; i++) {
+        for (int j = 0; j < size; j++) {
+            m1->data[i][j] = i + j;
+            m2->data[i][j] = i * j;
+        }
+    }
+    matrix *result = m1->multiply(m1, m2);
+    print_test_result(result != NULL && result->rows == size && result->cols == size, "Large matrix multiply");
+    m1->destroy(m1);
+    m2->destroy(m2);
+    result->destroy(result);
+}
+
 void run_all_tests() {
     test_matrix_add();
     test_matrix_subtract();
@@ -188,6 +205,7 @@ void run_all_tests() {
     test_matrix_determinant();
     test_matrix_transpose();
     test_matrix_inverse();
+    test_matrix_large_multiply();
 }
 
 int main() {

--- a/test/test_matrix_extra.c
+++ b/test/test_matrix_extra.c
@@ -50,6 +50,14 @@ void test_matrix_inverse_singular() {
     m->destroy(m);
 }
 
+void test_matrix_determinant_non_square() {
+    matrix *m = create_matrix(2,3);
+    int err = 0;
+    double det = m->determinant(m, &err);
+    print_test_result(err != 0 && det == 0, "Determinant on non-square matrix errors");
+    m->destroy(m);
+}
+
 void test_vector_resize() {
     vector *v = create_vector(2);
     v->data[0] = 1; v->data[1] = 2;
@@ -65,6 +73,7 @@ void run_all_tests() {
     test_matrix_resize();
     test_matrix_copy();
     test_matrix_inverse_singular();
+    test_matrix_determinant_non_square();
     test_vector_resize();
 }
 

--- a/test/test_priority_queue.c
+++ b/test/test_priority_queue.c
@@ -20,6 +20,12 @@ void test_priority_queue_empty_initially() {
     pq->free(pq);
 }
 
+void test_priority_queue_dequeue_empty() {
+    queue *pq = create_queue(QUEUE_TYPE_PRIORITY, 10, int_compare_binary);
+    print_test_result(pq->dequeue(pq) == NULL, "Dequeue on empty priority queue returns NULL");
+    pq->free(pq);
+}
+
 void test_priority_queue_enqueue_dequeue() {
     queue *pq = create_queue(QUEUE_TYPE_PRIORITY, 10, int_compare_binary);
     int data1 = 42;
@@ -53,7 +59,7 @@ void test_priority_queue_multiple_elements() {
 
 void test_priority_queue_high_volume() {
     queue *pq = create_queue(QUEUE_TYPE_PRIORITY, 10, int_compare_binary);
-    const int max_data = 10000;
+    const int max_data = 20000;  // Increased for more exhaustive coverage
     int* data_array = generate_random_int_data(max_data);
 
     for (int i = 0; i < max_data; i++) {
@@ -77,6 +83,7 @@ void test_priority_queue_high_volume() {
 
 void run_all_priority_queue_tests() {
     test_priority_queue_empty_initially();
+    test_priority_queue_dequeue_empty();
     test_priority_queue_enqueue_dequeue();
     test_priority_queue_multiple_elements();
     test_priority_queue_high_volume();

--- a/test/test_queue.c
+++ b/test/test_queue.c
@@ -8,6 +8,12 @@ void test_queue_empty_initially() {
     q->free(q);
 }
 
+void test_queue_dequeue_empty() {
+    queue *q = create_queue(QUEUE_TYPE_NORMAL, 10, NULL);
+    print_test_result(q->dequeue(q) == NULL, "Dequeue on empty queue returns NULL");
+    q->free(q);
+}
+
 void test_queue_enqueue_dequeue_single() {
     queue *q = create_queue(QUEUE_TYPE_NORMAL, 10, NULL);
     int data1 = 42;
@@ -35,7 +41,7 @@ void test_queue_enqueue_dequeue_multiple() {
 
 void test_queue_high_volume() {
     queue *q = create_queue(QUEUE_TYPE_NORMAL, 10, NULL);
-    const int max_data = 1000;  // Use a smaller number for demo
+    const int max_data = 5000;  // Larger dataset for more exhaustive testing
     int* data_array = generate_random_int_data(max_data);
 
     for (int i = 0; i < max_data; i++) {
@@ -65,6 +71,7 @@ void test_queue_with_string_data() {
 
 void run_all_queue_tests() {
     test_queue_empty_initially();
+    test_queue_dequeue_empty();
     test_queue_enqueue_dequeue_single();
     test_queue_enqueue_dequeue_multiple();
     test_queue_high_volume();

--- a/test/test_sorter.c
+++ b/test/test_sorter.c
@@ -15,6 +15,15 @@ int int_compare(const void *a, const void *b) {
     return (arg1 > arg2) - (arg1 < arg2);
 }
 
+void test_sort_empty_list() {
+    list *lst = create_list(ARRAY_LIST, 1);
+    sorter *s = create_sorter(lst, int_compare);
+    s->sort(s, lst); /* should handle empty list */
+    print_test_result(lst->size(lst) == 0, "Sort on empty list safe");
+    lst->free(lst);
+    free(s);
+}
+
 
 void test_sorter_sort() {
     list *lst = create_list(ARRAY_LIST, 10);
@@ -172,6 +181,7 @@ void run_all_tests() {
     test_sorter_binary_search();
     test_sorter_copy();
     test_sorter_min_max();
+    test_sort_empty_list();
 }
 
 int main() {


### PR DESCRIPTION
## Summary
- integrate queue edge case tests and increase high-volume loops
- extend priority queue, heap, list, stack, matrix and sorter test coverage
- drop separate `test_edge_cases` file and remove from build

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure --timeout 10` *(fails: test_fibonacci_heap timeout)*