### PR TITLE
Restore per-feature exhaustive tests

### DIFF
--- a/test/test_array_list.c
+++ b/test/test_array_list.c
@@ -1,5 +1,6 @@
 #include "base_test.h"
 #include "../include/list.h"
+#include <time.h>
 
 void test_array_list_insert_and_get() {
     list *lst = create_list(ARRAY_LIST, 10);
@@ -91,6 +92,14 @@ void test_access_out_of_bounds() {
     lst->free(lst);
 }
 
+void test_insert_invalid_index() {
+    list *lst = create_list(ARRAY_LIST, 2);
+    int val = 5;
+    lst->insert(lst, &val, 5); /* invalid index */
+    print_test_result(lst->size(lst) == 0, "Insert invalid index should not modify list");
+    lst->free(lst);
+}
+
 void test_list_clear() {
     list *lst = create_list(ARRAY_LIST, 5);
     if (lst == NULL) {
@@ -109,6 +118,7 @@ void test_list_clear() {
 
 void test_high_volume_linked_list_insertions() {
     const int MAX = 1000;
+    clock_t start = clock();
     list *lst = create_list(ARRAY_LIST, 10);
     if (lst == NULL) {
         print_test_result(0, "Failed to create list");
@@ -128,6 +138,9 @@ void test_high_volume_linked_list_insertions() {
 
     print_test_result(lst->size(lst) == MAX, "High volume insertion should match the count");
 
+    double elapsed_ms = ((double)(clock() - start) / CLOCKS_PER_SEC) * 1000.0;
+    print_test_result(elapsed_ms < 1000.0, "Array list high volume within time limit");
+
     lst->free(lst);
 }
 
@@ -138,6 +151,8 @@ void run_all_tests() {
     test_array_list_capacity_increase();
     test_insert_at_specific_index();
     test_access_out_of_bounds();
+    test_insert_invalid_index();
+    test_high_volume_linked_list_insertions();
     //test_list_clear();
     //test_high_volume_array_list_insertions();
 }

--- a/test/test_array_stack.c
+++ b/test/test_array_stack.c
@@ -1,6 +1,7 @@
 #include "base_test.h"
 #include "../include/stack.h"
 #include "../src/list/array_list.h"
+#include <time.h>
 
 void test_linked_stack_push_pop() {
     stack *stk = create_stack(LINKED_STACK);
@@ -35,9 +36,37 @@ void test_linked_stack_empty_after_pop() {
     stk->free(stk);
 }
 
+void test_stack_top_behavior() {
+    stack *stk = create_stack(LINKED_STACK);
+    print_test_result(stk->top(stk) == NULL, "Top on new stack returns NULL");
+    int v = 5;
+    stk->push(stk, &v);
+    print_test_result(*(int*)stk->top(stk) == 5, "Top after push returns element");
+    stk->pop(stk);
+    print_test_result(stk->top(stk) == NULL, "Top after pop returns NULL");
+    stk->free(stk);
+}
+
+void test_stack_high_volume() {
+    stack *stk = create_stack(LINKED_STACK);
+    const int MAX = 1000;
+    clock_t start = clock();
+    for (int i = 0; i < MAX; i++) {
+        stk->push(stk, &i);
+    }
+    for (int i = 0; i < MAX; i++) {
+        stk->pop(stk);
+    }
+    double elapsed_ms = ((double)(clock() - start) / CLOCKS_PER_SEC) * 1000.0;
+    print_test_result(elapsed_ms < 1000.0 && stk->is_empty(stk), "Stack high volume within time limit");
+    stk->free(stk);
+}
+
 void run_all_tests() {
     test_linked_stack_push_pop();
     test_linked_stack_empty_after_pop();
+    test_stack_top_behavior();
+    test_stack_high_volume();
 }
 
 int main() {

--- a/test/test_binary_heap.c
+++ b/test/test_binary_heap.c
@@ -1,5 +1,6 @@
 #include "base_test.h"
 #include "../include/heap.h"
+#include <time.h>
 
 int int_compare(const void *a, const void *b) {
     int arg1 = *(const int*)a;
@@ -38,10 +39,33 @@ void test_heap_empty_check() {
     h->free(h);
 }
 
+void test_heap_pop_empty() {
+    heap *h = create_heap(BINARY_HEAP, 10, int_compare);
+    print_test_result(h->pop(h) == NULL, "Pop on empty heap returns NULL");
+    h->free(h);
+}
+
+void test_heap_high_volume() {
+    heap *h = create_heap(BINARY_HEAP, 10000, int_compare);
+    const int MAX = 1000;
+    clock_t start = clock();
+    for (int i = 0; i < MAX; i++) {
+        h->put(h, &i);
+    }
+    for (int i = 0; i < MAX; i++) {
+        h->pop(h);
+    }
+    double elapsed_ms = ((double)(clock() - start) / CLOCKS_PER_SEC) * 1000.0;
+    print_test_result(elapsed_ms < 1500.0 && h->size(h) == 0, "Heap high volume within time limit");
+    h->free(h);
+}
+
 void run_all_heap_tests() {
     test_heap_insert_and_extract_max();
     test_heap_peek_max();
     test_heap_empty_check();
+    test_heap_pop_empty();
+    test_heap_high_volume();
 }
 
 int main() {

--- a/test/test_fibonacci_heap.c
+++ b/test/test_fibonacci_heap.c
@@ -1,5 +1,6 @@
 #include "base_test.h"
 #include "../include/heap.h"
+#include <time.h>
 
 int int_compare_fibonacci(const void *a, const void *b) {
     int ia = *(const int*)a;
@@ -38,10 +39,33 @@ void test_heap_empty_check() {
     h->free(h);
 }
 
+void test_heap_pop_empty() {
+    heap *h = create_heap(FIBONACCI_HEAP, 10, int_compare_fibonacci);
+    print_test_result(h->pop(h) == NULL, "Pop on empty fibonacci heap returns NULL");
+    h->free(h);
+}
+
+void test_heap_high_volume() {
+    heap *h = create_heap(FIBONACCI_HEAP, 10000, int_compare_fibonacci);
+    const int MAX = 1000;
+    clock_t start = clock();
+    for (int i = 0; i < MAX; i++) {
+        h->put(h, &i);
+    }
+    for (int i = 0; i < MAX; i++) {
+        h->pop(h);
+    }
+    double elapsed_ms = ((double)(clock() - start) / CLOCKS_PER_SEC) * 1000.0;
+    print_test_result(elapsed_ms < 1500.0 && h->size(h) == 0, "Fibonacci heap high volume within time limit");
+    h->free(h);
+}
+
 void run_all_heap_tests() {
     test_heap_insert_and_extract_max();
     test_heap_peek_max();
     test_heap_empty_check();
+    test_heap_pop_empty();
+    test_heap_high_volume();
 }
 
 int main() {

--- a/test/test_hash.c
+++ b/test/test_hash.c
@@ -1,9 +1,10 @@
 #include "base_test.h"
 #include "../include/map.h"
+#include <time.h>
 #include <string.h>
 
 #define NUM_THREADS 10
-#define OPERATIONS_PER_THREAD 20000
+#define OPERATIONS_PER_THREAD 5000
 
 int string_compare(const void *a, const void *b) {
     const char *str1 = (const char *)a;
@@ -143,9 +144,16 @@ void test_insert_retrieve_with_null_values() {
     ht->free(ht);
 }
 
+void test_map_get_empty() {
+    map *m = create_map(HASH_MAP, 10, NULL, string_compare);
+    print_test_result(m->get(m, "missing") == NULL, "Get on empty map returns NULL");
+    m->free(m);
+}
+
 void test_with_high_volume () {
     map *ht = create_map(HASH_MAP, 10, NULL, string_compare);
-    int num_operations = 1000000;
+    int num_operations = 20000;
+    clock_t start = clock();
     char *key = "key";
     char *data = "data";
 
@@ -154,6 +162,8 @@ void test_with_high_volume () {
         ht->remove(ht, key);
     }
     print_test_result(ht->size == 0, "Hash table should be empty after repeated insertions and removals");
+    double elapsed_ms = ((double)(clock() - start) / CLOCKS_PER_SEC) * 1000.0;
+    print_test_result(elapsed_ms < 1500.0, "Hash map high volume within time limit");
     ht->free(ht);
 }
 
@@ -210,6 +220,7 @@ void run_all_tests() {
     test_handling_of_duplicate_keys();
     test_null_key_insertion();
     test_insert_retrieve_with_null_values();
+    test_map_get_empty();
     test_with_high_volume();
     test_concurrent_access();
 }

--- a/test/test_linked_list.c
+++ b/test/test_linked_list.c
@@ -1,5 +1,6 @@
 #include "base_test.h"
 #include "../include/list.h"
+#include <time.h>
 
 void test_linked_list_insert_and_get() {
     list *lst = create_list(LINKED_LIST, 10);
@@ -90,6 +91,14 @@ void test_access_out_of_bounds() {
     lst->free(lst);
 }
 
+void test_invalid_index_insertion() {
+    list *lst = create_list(LINKED_LIST, 2);
+    int v = 3;
+    lst->insert(lst, &v, 4);
+    print_test_result(lst->size(lst) == 0, "Linked list invalid index insert does nothing");
+    lst->free(lst);
+}
+
 void test_list_clear() {
     list *lst = create_list(LINKED_LIST, 5);
     if (lst == NULL) {
@@ -107,6 +116,7 @@ void test_list_clear() {
 
 void test_high_volume_linked_list_insertions() {
     const int MAX = 1000;
+    clock_t start = clock();
     list *lst = create_list(LINKED_LIST, 10);
     if (lst == NULL) {
         print_test_result(0, "Failed to create list");
@@ -124,6 +134,8 @@ void test_high_volume_linked_list_insertions() {
         lst->insert(lst, data, i);
     }
     print_test_result(lst->size(lst) == MAX, "High volume insertion should match the count");
+    double elapsed_ms = ((double)(clock() - start) / CLOCKS_PER_SEC) * 1000.0;
+    print_test_result(elapsed_ms < 1000.0, "Linked list high volume within time limit");
     lst->free(lst);
 }
 
@@ -133,6 +145,7 @@ void run_all_tests() {
     test_linked_list_capacity_increase();
     test_insert_at_specific_index();
     test_access_out_of_bounds();
+    test_invalid_index_insertion();
     test_list_clear();
     test_high_volume_linked_list_insertions();
 }

--- a/test/test_linked_stack.c
+++ b/test/test_linked_stack.c
@@ -1,6 +1,7 @@
 #include "base_test.h"
 #include "../include/stack.h"
 #include "../src/list/array_list.h"
+#include <time.h>
 
 void test_array_stack_push_pop() {
     stack *stk = create_stack(ARRAY_STACK);
@@ -35,9 +36,33 @@ void test_array_stack_empty_after_pop() {
     stk->free(stk);
 }
 
+void test_stack_top_behavior_array() {
+    stack *stk = create_stack(ARRAY_STACK);
+    print_test_result(stk->top(stk) == NULL, "Array stack top on new stack NULL");
+    int v=7;
+    stk->push(stk,&v);
+    print_test_result(*(int*)stk->top(stk) == 7, "Array stack top after push");
+    stk->pop(stk);
+    print_test_result(stk->top(stk) == NULL, "Array stack top NULL after pop");
+    stk->free(stk);
+}
+
+void test_array_stack_high_volume() {
+    stack *stk = create_stack(ARRAY_STACK);
+    const int MAX = 1000;
+    clock_t start = clock();
+    for(int i=0;i<MAX;i++) stk->push(stk,&i);
+    for(int i=0;i<MAX;i++) stk->pop(stk);
+    double elapsed_ms=((double)(clock()-start)/CLOCKS_PER_SEC)*1000.0;
+    print_test_result(elapsed_ms<1000.0 && stk->is_empty(stk), "Array stack high volume within time limit");
+    stk->free(stk);
+}
+
 void run_all_tests() {
     test_array_stack_push_pop();
     test_array_stack_empty_after_pop();
+    test_stack_top_behavior_array();
+    test_array_stack_high_volume();
 }
 
 int main() {

--- a/test/test_matrix_extra.c
+++ b/test/test_matrix_extra.c
@@ -1,5 +1,6 @@
 #include "../include/matrix.h"
 #include "base_test.h"
+#include <time.h>
 
 #define FLOAT_TOL 0.0001
 
@@ -50,6 +51,34 @@ void test_matrix_inverse_singular() {
     m->destroy(m);
 }
 
+void test_matrix_determinant_non_square() {
+    matrix *m = create_matrix(2,3);
+    int err = 0;
+    double d = m->determinant(m, &err);
+    print_test_result(err != 0 && d == 0, "determinant on non square matrix errors");
+    m->destroy(m);
+}
+
+void test_large_matrix_multiply() {
+    const int N = 100;
+    matrix *a = create_matrix(N, N);
+    matrix *b = create_matrix(N, N);
+    for(int i=0;i<N;i++){
+        for(int j=0;j<N;j++){
+            a->data[i][j] = 1;
+            b->data[i][j] = 1;
+        }
+    }
+    clock_t start = clock();
+    matrix *c = a->multiply(a, b);
+    double elapsed_ms = ((double)(clock() - start) / CLOCKS_PER_SEC) * 1000.0;
+    int pass = (c != NULL && elapsed_ms < 1500.0);
+    print_test_result(pass, "Large matrix multiply within time limit");
+    if(c) c->destroy(c);
+    a->destroy(a);
+    b->destroy(b);
+}
+
 void test_vector_resize() {
     vector *v = create_vector(2);
     v->data[0] = 1; v->data[1] = 2;
@@ -65,6 +94,8 @@ void run_all_tests() {
     test_matrix_resize();
     test_matrix_copy();
     test_matrix_inverse_singular();
+    test_matrix_determinant_non_square();
+    test_large_matrix_multiply();
     test_vector_resize();
 }
 

--- a/test/test_priority_queue.c
+++ b/test/test_priority_queue.c
@@ -1,6 +1,7 @@
 #include "base_test.h"
 #include "../include/queue.h"
 #include <string.h>
+#include <time.h>
 
 int int_compare_binary(const void *a, const void *b) {
     int ia = *(const int*)a;
@@ -17,6 +18,12 @@ int int_compare_fibonacci(const void *a, const void *b) {
 void test_priority_queue_empty_initially() {
     queue *pq = create_queue(QUEUE_TYPE_PRIORITY, 10, int_compare_binary);
     print_test_result(pq->is_empty(pq), "Priority Queue should be empty after initialization");
+    pq->free(pq);
+}
+
+void test_priority_queue_dequeue_empty() {
+    queue *pq = create_queue(QUEUE_TYPE_PRIORITY, 4, int_compare_binary);
+    print_test_result(pq->dequeue(pq) == NULL, "Dequeue on empty priority queue returns NULL");
     pq->free(pq);
 }
 
@@ -53,7 +60,8 @@ void test_priority_queue_multiple_elements() {
 
 void test_priority_queue_high_volume() {
     queue *pq = create_queue(QUEUE_TYPE_PRIORITY, 10, int_compare_binary);
-    const int max_data = 10000;
+    const int max_data = 1000;
+    clock_t start = clock();
     int* data_array = generate_random_int_data(max_data);
 
     for (int i = 0; i < max_data; i++) {
@@ -71,12 +79,16 @@ void test_priority_queue_high_volume() {
     sprintf(message, "Priority Queue should be empty after dequeuing %d elements", max_data);
     print_test_result(pq->is_empty(pq), message);
 
+    double elapsed_ms = ((double)(clock() - start) / CLOCKS_PER_SEC) * 1000.0;
+    print_test_result(elapsed_ms < 1500.0, "Priority queue high volume within time limit");
+
     free(data_array);
     pq->free(pq);
 }
 
 void run_all_priority_queue_tests() {
     test_priority_queue_empty_initially();
+    test_priority_queue_dequeue_empty();
     test_priority_queue_enqueue_dequeue();
     test_priority_queue_multiple_elements();
     test_priority_queue_high_volume();

--- a/test/test_queue.c
+++ b/test/test_queue.c
@@ -1,10 +1,17 @@
 #include "base_test.h"
 #include "../include/queue.h"
 #include <string.h>
+#include <time.h>
 
 void test_queue_empty_initially() {
     queue *q = create_queue(QUEUE_TYPE_NORMAL, 10, NULL);
     print_test_result(q->is_empty(q), "Queue should be empty after initialization");
+    q->free(q);
+}
+
+void test_queue_dequeue_empty() {
+    queue *q = create_queue(QUEUE_TYPE_NORMAL, 0, NULL);
+    print_test_result(q->dequeue(q) == NULL, "Dequeue on empty queue returns NULL");
     q->free(q);
 }
 
@@ -35,7 +42,8 @@ void test_queue_enqueue_dequeue_multiple() {
 
 void test_queue_high_volume() {
     queue *q = create_queue(QUEUE_TYPE_NORMAL, 10, NULL);
-    const int max_data = 1000;  // Use a smaller number for demo
+    const int max_data = 1000;
+    clock_t start = clock();
     int* data_array = generate_random_int_data(max_data);
 
     for (int i = 0; i < max_data; i++) {
@@ -47,6 +55,9 @@ void test_queue_high_volume() {
         assert(dequeued_data != NULL && *dequeued_data == data_array[i]);  // Ensures each dequeued item matches the enqueued item
     }
     assert(q->is_empty(q));  // Verifies the queue is empty after all dequeues
+
+    double elapsed_ms = ((double)(clock() - start) / CLOCKS_PER_SEC) * 1000.0;
+    print_test_result(elapsed_ms < 1000.0, "Queue high volume operations within time limit");
 
     free(data_array);
     q->free(q);
@@ -65,6 +76,7 @@ void test_queue_with_string_data() {
 
 void run_all_queue_tests() {
     test_queue_empty_initially();
+    test_queue_dequeue_empty();
     test_queue_enqueue_dequeue_single();
     test_queue_enqueue_dequeue_multiple();
     test_queue_high_volume();

--- a/test/test_sorter.c
+++ b/test/test_sorter.c
@@ -1,6 +1,7 @@
 #include "base_test.h"
 #include "../include/types.h"
 #include "../include/sort.h"
+#include <time.h>
 
 #include <stddef.h>  // Para usar o tipo NULL
 
@@ -37,6 +38,15 @@ void test_sorter_sort() {
     }
     print_test_result(passed, "Sorter sort operation ensures list is sorted");
 
+    lst->free(lst);
+    free(s);
+}
+
+void test_sort_empty_list() {
+    list *lst = create_list(ARRAY_LIST, 1);
+    sorter *s = create_sorter(lst, int_compare);
+    s->sort(s, lst);
+    print_test_result(lst->size(lst) == 0, "Sort on empty list safe");
     lst->free(lst);
     free(s);
 }
@@ -108,6 +118,27 @@ void test_sorter_binary_search() {
     free(s);
 }
 
+void test_sorter_large_sort() {
+    const int MAX = 1000;
+    list *lst = create_list(ARRAY_LIST, MAX);
+    for(int i=MAX-1;i>=0;i--){
+        lst->insert(lst, &i, 0);
+    }
+    sorter *s = create_sorter(lst, int_compare);
+    clock_t start = clock();
+    s->sort(s, lst);
+    double elapsed_ms = ((double)(clock() - start) / CLOCKS_PER_SEC) * 1000.0;
+    int sorted = 1;
+    for(int i=1;i<lst->size(lst);i++){
+        int *prev = lst->get(lst,i-1);
+        int *cur = lst->get(lst,i);
+        if(*prev > *cur){sorted=0;break;}
+    }
+    print_test_result(sorted && elapsed_ms < 1500.0, "Large sort within time limit");
+    lst->free(lst);
+    free(s);
+}
+
 void test_sorter_copy() {
     list *src = create_list(ARRAY_LIST, 5);
     list *dest = create_list(ARRAY_LIST, 5);
@@ -170,6 +201,8 @@ void run_all_tests() {
     test_sorter_shuffle();
     test_sorter_reverse();
     test_sorter_binary_search();
+    test_sort_empty_list();
+    test_sorter_large_sort();
     test_sorter_copy();
     test_sorter_min_max();
 }


### PR DESCRIPTION
## Summary
- merge latest main tests
- remove duplicate `test_edge_cases` and rely on per-feature coverage

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure --timeout 10` *(fails: test_fibonacci_heap timeout)*