### PR TITLE
Initialize lp_problem defaults and add solver regression test

### DIFF
--- a/src/solver/solver.c
+++ b/src/solver/solver.c
@@ -35,6 +35,11 @@ lp_problem *create_problem(int numVariables, int numConstraints) {
     return NULL;
   }
 
+  // Ensure optional fields are initialized to safe defaults
+  problem->solution = NULL;
+  problem->z_value = 0.0;
+  problem->type = PROBLEM_MAX;
+
   // Assign utility functions
   problem->addConstraint = solver_add_constraint;
   problem->setObjective = solver_set_objective;

--- a/test/test_solver.c
+++ b/test/test_solver.c
@@ -47,6 +47,35 @@ void test_simplex_solver1() {
   }
 }
 
+void test_solver_initializes_solution_vector() {
+  int numVariables = 2;
+  int numConstraints = 2;
+  lp_problem *problem = create_problem(numVariables, numConstraints);
+
+  double objective_coeffs[] = {1, 1};
+  problem->setObjective(problem, objective_coeffs, PROBLEM_MAX);
+
+  double constraint1[] = {1, 0};
+  double constraint2[] = {0, 1};
+  problem->addConstraint(problem, constraint1, 1);
+  problem->addConstraint(problem, constraint2, 1);
+
+  solver *mySolver = create_solver(SOLVER_SIMPLEX);
+  matrix *solution = NULL;
+  int result = mySolver->solve(problem, &solution);
+
+  if (result == OPTIMAL && problem->solution != NULL) {
+    printf("Solver initialized solution vector successfully. x1 = %f, x2 = %f, z = %f\n",
+           problem->solution[0], problem->solution[1], problem->z_value);
+  } else {
+    printf("Solver failed to initialize solution vector.\n");
+  }
+
+  if (solution) {
+    solution->destroy(solution);
+  }
+}
+
 void test_simplex_solver2() {
   int numVariables = 3;
   int numConstraints = 3;
@@ -79,6 +108,7 @@ void test_simplex_solver2() {
 }
 
 int main() {
+  test_solver_initializes_solution_vector();
   test_simplex_solver1();
   test_simplex_solver2();
   return 0;


### PR DESCRIPTION
## Summary
- initialize the lp problem solution pointer, objective value, and default type when creating a problem
- add a regression test to solve a fresh problem and ensure the solver allocates the solution vector safely