### PR TITLE
Improve matrix resize error handling

### DIFF
--- a/include/matrix.h
+++ b/include/matrix.h
@@ -117,7 +117,7 @@ typedef struct matrix {
     * @param newRows The new number of rows for the matrix.
     * @param newCols The new number of columns for the matrix.
     */
-    void (*resize)(struct matrix *self, int newRows, int newCols);
+    int (*resize)(struct matrix *self, int newRows, int newCols);
 
     struct matrix* (*copy)(struct matrix *self);
 } matrix;

--- a/src/solver/solver.c
+++ b/src/solver/solver.c
@@ -73,7 +73,10 @@ static void solver_add_constraint(lp_problem *self, double *coefficients, double
   int currentRows = self->constraints->rows;
 
   // Resize the matrix to accommodate one more constraint
-  self->constraints->resize(self->constraints, currentRows + 1, self->constraints->cols);
+  if (self->constraints->resize(self->constraints, currentRows + 1,
+                                self->constraints->cols) != 0) {
+    return;
+  }
 
   // Set the new constraint's coefficients
   for (int i = 0; i < self->constraints->cols; i++) {


### PR DESCRIPTION
## Summary
- rework `matrix_resize` to return a status code and avoid mutating state until allocations succeed
- guard solver constraint growth against resize failures
- extend matrix extra tests to cover shrinking, expanding, and failure scenarios