### PR TITLE
Rewrite docs for prose-style wiki usage

### DIFF
--- a/docs/containers.md
+++ b/docs/containers.md
@@ -2,68 +2,55 @@
 
 ## Lists
 ### Common contract
-- `create_list` selects an implementation based on `ListType` and wires function pointers for `insert`, `get`, `remove`, `size`, and `free` so callers interact through a uniform API.
-- Payload ownership is external. Removing an item unlinks the node or shifts slots but never frees the pointer stored by the user.
+List creation routes through `create_list`, which selects an implementation according to the requested `ListType` and wires function pointers for `insert`, `get`, `remove`, `size`, and `free`. Callers interact with the returned handle rather than concrete structures. Ownership of payload pointers always stays with the caller; removing an element simply unlinks the node or shifts slots without freeing the stored pointer.
 
 ### Array list (`ARRAY_LIST`)
-- Backed by a contiguous `void **` buffer stored in `array_list_impl`. Capacity doubles via `realloc` when the write pointer reaches the end, giving amortized O(1) growth for append-heavy workloads.
-- `insert` calls `memmove` to open a gap before writing the new element; worst-case cost is O(n) when inserting at the head.
-- `remove` also uses `memmove` to collapse the gap. Reads are O(1) because `get` dereferences the array directly.
-- A static counter `active_item_buffers` tracks allocated backing arrays for diagnostic purposes.
+The array-backed list stores elements in a contiguous `void **` buffer inside `array_list_impl`. Capacity doubles through `realloc` whenever the write pointer reaches the end, giving amortized constant-time growth for append-heavy workloads. Insertions rely on `memmove` to open gaps, which yields O(n) cost in the worst case when targeting the head. Removals collapse gaps with another `memmove`. Reads are constant time because `get` dereferences the array directly. A diagnostic counter, `active_item_buffers`, tracks allocated backing arrays to help detect leaks during testing.
 
 ### Linked list (`LINKED_LIST`)
-- Doubly linked nodes (`linked_list_node`) carry `data`, `next`, and `prev` pointers. The implementation stores `head`, `tail`, and `size` inside `linked_list_impl`.
-- Insertion chooses the nearest end when walking to the target index to cap traversal at roughly n/2 comparisons. Head and tail insertions update sentinel pointers without traversal.
-- Removal fixes neighbor pointers before freeing the node, ensuring O(1) deletion when the node reference is known after traversal.
+Doubly linked nodes carry `data`, `next`, and `prev` pointers while the implementation keeps `head`, `tail`, and `size` in `linked_list_impl`. Insertion logic walks from the nearest end toward the requested index to cap traversal at roughly half the list when possible. Updating head or tail bypasses traversal entirely. Removal rewires neighbor pointers before releasing the node, giving constant-time deletion when the node reference is already known after traversal.
 
 ### Sorted array list (`SORTED_LIST`)
-- Requires a comparator at creation time; calls fail if `cmp == NULL`.
-- Maintains sorted order by binary searching (`find_insert_position`) for the insertion index and then shifting the tail with `memmove`. Lookup is O(1) by index, insert/remove remain O(n) due to shifting.
-- Capacity clamps to at least four slots and doubles when the array is full.
+Sorted lists demand a comparator during creation, and the factory rejects attempts to proceed without one. Each insertion performs a binary search through `find_insert_position` to locate the correct slot, shifts the tail with `memmove`, and maintains sorted order. Lookups by index remain constant time, while insertions and removals remain O(n) because of the required shifting. Capacity never drops below four slots and doubles when the array fills.
 
 ## Queues
 ### Linked FIFO queue
-- Implements an unbounded singly linked list of `queue_entry` nodes. `enqueue` appends at `rear`, `dequeue` pops from `front`, both O(1).
-- `initialize` resets `front`, `rear`, and `length` so queues can be reused after draining.
+The linked FIFO queue implements an unbounded singly linked chain of `queue_entry` nodes. `enqueue` appends at `rear`, `dequeue` pops from `front`, and both operations run in constant time. Reinitialization simply resets `front`, `rear`, and `length`, allowing queues to be reused once drained.
 
 ### Heap-backed priority queue
-- Wraps a heap created through `create_heap`. The queue delegates `enqueue` to `heap->put` and `dequeue` to `heap->pop`, exposing a priority queue while keeping the `queue` vtable consistent.
-- Size queries forward to the heap, and the comparator supplied at construction time controls ordering.
+Priority queues delegate their storage to a heap produced by `create_heap`. Enqueue operations forward to `heap->put`, while dequeues call `heap->pop`, maintaining the queue vtable without exposing heap details. Size queries also route to the heap, and the comparator supplied during construction determines ordering.
 
 ## Heaps
 ### Binary heap
-- Stores elements in a dynamic array. When `size == capacity`, capacity doubles and `realloc` migrates elements.
-- `put` inserts at the end and calls `sift_up` to restore heap order by comparing parents and swapping until the comparator no longer prefers the child.
-- `pop` replaces the root with the last element, decrements `size`, and `sift_down`s by repeatedly selecting the largest child (max-heap semantics) until the heap property is restored.
-- Time bounds: `put` and `pop` are O(log n); `peek` and `size` are O(1).
+The binary heap stores elements in a dynamic array that doubles capacity whenever size equals capacity. Inserting appends at the end and calls `sift_up` to compare against parent nodes until the heap property holds. Removing the top element replaces the root with the last entry, decrements size, and restores ordering via `sift_down`, choosing the highest-priority child on each step. Push and pop operations run in logarithmic time, while `peek` and `size` remain constant time.
 
 ### Fibonacci heap
-- Each heap node (`fib_node`) participates in a circular doubly linked root list. Nodes track `degree`, `parent`, `child`, and a Boolean `mark` flag.
-- Inserts splice the new node into the root list in O(1). The minimum pointer updates if the new key outranks the previous root.
-- `pop` removes the current minimum, promotes all of its children to the root list, and calls `consolidate`. Consolidation uses a fixed array of 45 buckets (`A[45]`) to link roots of equal degree, reflecting the upper bound on degrees for heaps with fewer than `φ^45` nodes (~10^9).
-- Cascading cuts are not yet implemented; decrease-key is absent, so marked nodes remain unused but keep the structure compatible with future extensions.
-- Amortized costs: `insert` O(1), `pop` O(log n) because consolidation links at most logarithmically many roots.
-- Memory reclamation walks circular sibling lists recursively to release children before freeing the heap wrapper.
+Fibonacci heaps organize nodes into a circular doubly linked root list where each node tracks its degree, parent, child, and a `mark` flag. Insertions splice nodes into the root list in constant time and update the minimum pointer if required. Removing the minimum promotes its children into the root list and triggers consolidation, which uses a fixed array of forty-five buckets (`A[45]`) to link roots of equal degree, matching the upper bound for heaps with fewer than `φ^45` nodes. Cascading cuts and decrease-key operations are not yet implemented, but the existing structure keeps the heap ready for those extensions. Inserts remain amortized constant time, while popping the minimum costs logarithmic time because consolidation processes only a logarithmic number of roots. Destruction walks the circular sibling lists recursively to reclaim children before freeing the heap wrapper.
 
 ## Stacks
-- Array-backed stacks reuse the array list to provide push/pop at the tail; linked stacks push/pop the head of a linked list. Both expose `top`, `is_empty`, `size`, and `free` consistent with the list contract.
+Stack abstractions reuse the list implementations. Array-backed stacks push and pop at the tail of the array list, and linked stacks update the head of a linked list. Both variants expose `top`, `is_empty`, `size`, and `free` in alignment with the list contract.
 
 ## Maps
 ### Structure
-- The map uses separate chaining. `map_entry` nodes store `key`, `data`, and `next` pointer. `buckets` points to an array of bucket heads with initial capacity clamped to `INITIAL_CAPACITY` (20).
-- `create_hash_map` assigns the function pointers for `put`, `get`, `remove`, and `free` and either wires a caller-supplied hash function or defaults to `bernstein_hash`.
-- When `map_type` is `HASH_TABLE`, the factory allocates a `pthread_mutex_t` and wraps all mutations and lookups with coarse-grained locking. Non-thread-safe instances leave `lock == NULL` for zero-overhead single-threaded use.
+The hash map relies on separate chaining with `map_entry` nodes that store `key`, `data`, and a `next` pointer. `buckets` points to an array whose initial capacity never falls below twenty. During creation, `create_hash_map` installs function pointers for `put`, `get`, `remove`, and `free`, while wiring either a caller-supplied hash routine or the default `bernstein_hash`. When the caller requests a thread-safe map, the factory allocates a `pthread_mutex_t` and wraps all lookups and mutations with coarse-grained locking. Single-threaded instances omit the mutex entirely to avoid overhead.
 
 ### Collision handling and resizing
-- `hash_insert` locks (if enabled), recomputes the load factor `size / capacity`, and triggers `resize_and_rehash` when the ratio exceeds 0.75. Resizing doubles `capacity`, allocates a new bucket array, and reuses existing `map_entry` nodes by recomputing their indices.
-- Collisions append new nodes at the head of the bucket’s linked list. Updating an existing key overwrites `data` in-place without reallocating the node.
-- `hash_get` hashes the key (treating NULL as bucket zero), walks the chain, and returns the stored `data` pointer. `hash_remove` fixes the singly linked chain before freeing the removed node and decrementing `size`.
-- Deallocation iterates every bucket, frees each `map_entry`, destroys the optional mutex, and finally frees the table.
+Insertion acquires the optional lock, recomputes the load factor as `size / capacity`, and calls `resize_and_rehash` when the ratio exceeds 0.75. Resizing doubles capacity, allocates a new bucket array, and reuses existing nodes after recalculating their indices. Collisions chain new nodes at the head of the bucket list. Updating an existing key overwrites the stored `data` pointer without reallocating the node. Lookup hashes the key—treating NULL as bucket zero—walks the chain, and returns the stored pointer. Removal stitches the singly linked list back together before freeing the node and decrementing size. Destruction iterates every bucket, frees each node, destroys the optional mutex, and then releases the table itself.
 
 ### Built-in hash functions
-- **Bernstein (djb2)**: multiplies the accumulator by 33 and adds each byte. Provides good distribution for short ASCII keys with minimal arithmetic.
-- **FNV-1a**: XORs each byte into the hash and multiplies by the FNV prime (16777619), trading a larger constant for improved avalanche properties on structured binary data.
-- **XOR folding**: Mixes left and right shifts with byte addition to decorrelate simple patterns; useful when inputs exhibit local repetition.
-- **Rotational**: Rotates the accumulator by combining left and right shifts before XORing the next byte; balances dispersion and cost for variable-length strings.
-- **Additive**: Simple byte summation; fastest but lowest quality, intended for tiny key sets where collisions are tolerable.
-- All functions short-circuit on `key == NULL`, forcing such entries into bucket zero so sentinel keys remain retrievable.
+#### Bernstein (djb2)
+The Bernstein implementation multiplies the accumulator by thirty-three and adds each byte, providing good distribution for short ASCII keys with minimal arithmetic.
+
+#### FNV-1a
+FNV-1a XORs each byte into the hash and multiplies by the prime 16777619, trading a slightly higher cost for stronger avalanche properties on structured binary inputs.
+
+#### XOR folding
+XOR folding mixes left and right shifts with byte addition to decorrelate simple patterns, making it a pragmatic choice when inputs exhibit local repetition.
+
+#### Rotational
+The rotational variant combines bit rotations and XOR to balance dispersion with execution cost on variable-length strings.
+
+#### Additive
+The additive approach simply sums bytes. It is the fastest option but yields the weakest distribution, suitable only for tiny key sets where collisions remain tolerable.
+
+All functions short-circuit when `key == NULL`, ensuring sentinel entries always hash to bucket zero and remain retrievable.

--- a/docs/matrix.md
+++ b/docs/matrix.md
@@ -1,29 +1,19 @@
 # Matrix and Vector Operations
 
 ## Allocation and lifecycle
-- `create_matrix` allocates a `matrix` wrapper plus `rows` pointers to contiguous `double` arrays. Allocation failures unwind previously allocated rows before returning NULL.
-- Function pointers for arithmetic (`add`, `subtract`, `multiply`), structural changes (`transpose`, `resize`, `copy`), and linear algebra operations (`determinant`, `inverse`) are set during construction so callers use one handle for all actions.
-- `matrix_destroy` frees each row then releases the wrapper. `matrix_copy` clones dimensions and performs `memcpy` on every row.
-- `create_vector` zero-initializes the buffer with `calloc`, wires `resize`, `print`, and `destroy`, and keeps ownership internal; solvers treat vectors as mutable views over raw coefficient arrays.
+`create_matrix` allocates a wrapper followed by row pointers to contiguous `double` arrays. Whenever an allocation fails, the function unwinds previously created rows and returns NULL so callers never see partially initialized structures. Construction wires function pointers for arithmetic, structural transformations, and linear algebra helpers, enabling callers to use a single handle for addition, subtraction, multiplication, transposition, resizing, copying, determinant evaluation, and inversion. `matrix_destroy` walks every row before freeing the wrapper, and `matrix_copy` duplicates the dimensions before cloning each row with `memcpy`. `create_vector` zero-initializes storage with `calloc`, assigns callbacks for resizing, printing, and destruction, and keeps ownership internal so solvers can treat vectors as mutable views over coefficient arrays.
 
 ## Arithmetic primitives
-- Addition and subtraction walk every cell in row-major order, producing a new matrix; both require identical shapes and run in O(m·n).
-- Multiplication checks the inner dimension (`self->cols == other->rows`) before performing the triple loop dot product. Runtime is O(m·n·p) for an m×n by n×p multiplication.
+Addition and subtraction traverse every cell in row-major order, producing a new matrix after verifying that both operands share identical shapes. Each operation runs in O(m·n). Multiplication checks that the inner dimensions match (`self->cols == other->rows`) before launching the classic triple-loop dot product with O(m·n·p) complexity for an m×n matrix multiplied by an n×p matrix.
 
 ## Determinant
-- `matrix_determinant` clones the operand into a working matrix and performs Gaussian elimination. Pivoting tries to swap with a lower row when a zero pivot appears and multiplies the determinant by −1 per swap.
-- The function multiplies diagonal entries after eliminating below the pivot, yielding O(n³) runtime. It returns zero when no suitable pivot exists and sets an error flag when inputs are invalid.
+`matrix_determinant` clones the operand into a temporary working matrix and performs Gaussian elimination. Whenever a pivot is zero, the routine searches lower rows for a viable swap, multiplies the determinant by −1 when a swap occurs, and continues elimination. Once the matrix is upper triangular, diagonal entries multiply together to yield the determinant in O(n³) time. The function returns zero when no suitable pivot exists and raises an error flag if inputs are invalid.
 
 ## Inverse
-- Gauss-Jordan elimination augments the matrix with an identity block and performs row operations until the left half becomes identity. Swapping logic mirrors the determinant routine.
-- Failure to find a non-zero pivot indicates a singular matrix; the function frees intermediate matrices and returns NULL. Otherwise the right half of the augmented matrix is copied into the result.
-- Complexity is O(n³); memory usage doubles the matrix width during elimination because of the augmented storage.
+Inversion relies on Gauss-Jordan elimination. The routine augments the matrix with an identity block, applies the same pivoting strategy used by the determinant implementation, and performs row operations until the left half becomes identity. Failing to find a non-zero pivot indicates a singular matrix; in that case the function releases intermediate allocations and returns NULL. Successful elimination copies the right half of the augmented matrix into the result. Complexity remains O(n³), and the augmented storage doubles the matrix width during computation.
 
 ## Structural utilities
-- `matrix_transpose` allocates a new matrix with flipped dimensions and swaps indices during assignment.
-- `matrix_resize` supports both shrinking and growth. It allocates a new grid, copies overlapping entries, zero-fills any expanded region, and frees the old grid, returning −1 on allocation failures.
-- `matrix_print` formats entries with three decimal precision, aiding solver debugging.
+`matrix_transpose` creates a new matrix with flipped dimensions and swaps indices during assignment. `matrix_resize` supports shrinking and expansion by allocating a new grid, copying overlapping entries, zero-filling any newly exposed region, and freeing the previous grid. The function returns −1 when allocation fails. `matrix_print` renders entries with three-decimal precision, which assists in debugging solver tableaux.
 
 ## Vector helpers
-- `vector_resize` reallocates the buffer, zeroing any newly exposed slots.
-- `vector_print` emits a comma-separated list inside brackets, while `vector_destroy` frees the buffer and wrapper.
+`vector_resize` reallocates the buffer while zeroing additional slots. `vector_print` emits a bracketed, comma-separated list of components, and `vector_destroy` frees both the buffer and the wrapper.

--- a/docs/solver-simplex.md
+++ b/docs/solver-simplex.md
@@ -1,31 +1,19 @@
 # Linear Programming Solver
 
 ## Problem model
-- `create_problem` provisions the constraint matrix (`numConstraints × numVariables`), objective vector, and bounds vector. Each allocation is validated; failures free all partially initialized components before returning NULL.
-- Problems start with `type = PROBLEM_MAX`, `solution = NULL`, and `z_value = 0`. Function pointers expose `addConstraint`, `setObjective`, `setBounds`, and `print` for incremental configuration.
-- `addConstraint` resizes the matrix by one row, copies the coefficients into the newly added row, grows the bounds vector, and stores the RHS. Constraints are interpreted as ≤ inequalities.
-- `setObjective` copies coefficients verbatim and records whether the problem is a maximization or minimization.
-- `setBounds` overwrites the RHS vector in place; callers must respect the current constraint count.
+`create_problem` provisions the constraint matrix with dimensions `numConstraints × numVariables`, the objective vector, and the bounds vector. Every allocation is validated, and failures trigger cleanup of partially initialized components before returning NULL. Newly created problems default to `type = PROBLEM_MAX`, `solution = NULL`, and `z_value = 0`. Function pointers expose `addConstraint`, `setObjective`, `setBounds`, and `print`, enabling incremental configuration. `addConstraint` grows the matrix by one row, copies the coefficients, expands the bounds vector, and stores the right-hand side while interpreting constraints as ≤ inequalities. `setObjective` copies coefficients verbatim and records whether the problem targets maximization or minimization. `setBounds` overwrites the RHS vector in place; callers must respect the active constraint count.
 
 ## Solver selection
-- `create_solver` instantiates a solver wrapper with `solve` and `destroy` function pointers. Only `SOLVER_SIMPLEX` is implemented today; other enum values return stubs but keep binary compatibility for future algorithms.
+`create_solver` instantiates a solver wrapper that wires `solve` and `destroy`. Only `SOLVER_SIMPLEX` is implemented today, while other enum values return stubs to preserve binary compatibility for future algorithms.
 
 ## Simplex initialization
-- `simplex_solver` validates that constraints, objective, and bounds are present before allocating a tableau with `rows + 1` rows and `cols + rows + 1` columns. The final column stores RHS values and the last row stores the objective.
-- Constraint rows copy coefficients directly and append slack variables on the diagonal. Bounds populate the RHS column.
-- The objective row stores the negated coefficients to model a maximization problem in canonical simplex form.
-- `out_tableau` returns the allocated tableau to the caller, who assumes ownership and must call `matrix->destroy` when finished.
+`simplex_solver` verifies that constraints, objective coefficients, and bounds exist before allocating a tableau sized to `rows + 1` by `cols + rows + 1`. Constraint rows copy coefficients directly and append slack variables along the diagonal. Bounds populate the final column, and the last row stores the objective with negated coefficients to model maximization in canonical simplex form. Ownership of the tableau transfers to the caller through `out_tableau`, which must eventually invoke `matrix->destroy`.
 
 ## Pivot strategy
-- The solver scans the objective row from left to right and chooses the first negative coefficient as the entering variable (a Bland-like rule that mitigates cycling).
-- The minimum ratio test divides each RHS by the pivot column entry for rows with positive pivot column entries, selecting the smallest ratio as the leaving variable. Lack of a valid pivot row signals an unbounded problem.
-- Pivoting normalizes the pivot row by dividing by the pivot value, then subtracts multiples of the pivot row from every other row to zero the pivot column.
+The solver scans the objective row from left to right and chooses the first negative coefficient as the entering variable, following a Bland-style rule that mitigates cycling. The minimum ratio test divides each right-hand side by the corresponding pivot column entry for rows with positive entries, selecting the smallest ratio as the leaving variable. When no valid pivot row exists, the problem is marked unbounded. Pivoting normalizes the chosen row by dividing by the pivot value, then subtracts multiples of that row from every other row to zero the pivot column.
 
 ## Termination and reporting
-- When no negative coefficients remain in the objective row, the solution is optimal. The solver reconstructs basic variable values by scanning each column for unit vectors and reading the associated RHS entry.
-- `prob->solution` is allocated on demand and filled with the recovered basic variable values; nonbasic variables default to zero.
-- `prob->z_value` records the objective value as stored in the tableau’s last row, last column (already negated back to the maximization value).
-- The solver returns `OPTIMAL`, `UNBOUNDED`, or `INFEASIBLE` depending on validation and pivot outcomes.
+When the objective row contains no negative coefficients, the solution is optimal. The solver reconstructs basic variable values by scanning each column for unit vectors and reading the associated right-hand-side entry. `prob->solution` allocates storage on demand and fills it with recovered basic variable values while leaving nonbasic variables at zero. `prob->z_value` records the objective as the negated value stored in the tableau’s last row and column. The solver reports `OPTIMAL`, `UNBOUNDED`, or `INFEASIBLE` depending on validation and pivot outcomes.
 
 ## Utility hooks
-- `is_feasible` evaluates whether a candidate solution satisfies all constraints; `improves_objective` compares objective deltas, and `is_integer` tests integrality using an epsilon threshold. These helpers are currently unused by the simplex loop but prepare for branch-and-bound and cutting-plane integrations.
+Helper functions such as `is_feasible`, `improves_objective`, and `is_integer` assess constraints, objective deltas, and integrality using an epsilon threshold. They remain unused by the simplex loop today but lay groundwork for branch-and-bound or cutting-plane integrations.

--- a/docs/sorting.md
+++ b/docs/sorting.md
@@ -1,26 +1,19 @@
 # Sorting Utilities
 
 ## Sorter factory
-- `create_sorter` builds a lightweight object storing the comparator and wiring helper callbacks. The quicksort routine is assigned to `sort`, while `swap`, `shuffle`, `reverse`, `binary_search`, `copy`, `min`, `max`, and `min_max` compose higher-level operations.
-- The sorter operates on the abstract `list` interface, enabling the same algorithm to drive array lists, linked lists, or custom list implementations that respect the contract.
+`create_sorter` builds a lightweight object that records the comparator and wires helper callbacks. Quicksort is exposed through the `sort` entry, while `swap`, `shuffle`, `reverse`, `binary_search`, `copy`, `min`, `max`, and `min_max` compose higher-level operations. Because the sorter operates on the abstract `list` interface, the same algorithm can manipulate array lists, linked lists, or custom implementations that follow the contract.
 
 ## Element swapping semantics
-- `sorter_swap` reads both elements, removes them from the list, and reinserts them at the opposite indices. This approach avoids requiring random-access writes on the underlying storage and preserves invariants for list implementations that might track metadata on `insert`/`remove`.
-- The cost is two removals and two insertions per swap; array lists pay O(n) per swap, while linked lists pay O(n) for traversal plus O(1) for relinking.
+`sorter_swap` reads both targeted elements, removes them from the list, and reinserts them at the opposite indices. This approach avoids assuming random-access writes on the underlying storage and preserves invariants for list implementations that might track metadata inside their `insert` and `remove` calls. Each swap performs two removals and two insertions; array lists therefore pay O(n) per swap, whereas linked lists spend O(n) on traversal plus O(1) on relinking.
 
 ## Iterative quicksort
-- `sorter_quick` implements non-recursive quicksort using an explicit stack sized at `2 * list->size(list)` integers to hold pending subranges. This sidesteps recursion limits and makes stack usage predictable.
-- Partitioning chooses the high index as the pivot. Elements less than or equal to the pivot swap forward; finally the pivot is swapped into its final position. Average runtime is O(n log n), worst-case O(n²) if the list is already sorted and the pivot degenerates.
-- The implementation is stable under re-entrancy because it allocates the working stack per invocation and frees it before returning.
+`sorter_quick` implements a non-recursive quicksort that relies on an explicit stack sized at twice the list length to store pending subranges. Partitioning chooses the high index as the pivot. Elements less than or equal to the pivot swap forward, and the pivot finally moves into its resolved position. Average runtime remains O(n log n), while worst-case behavior reaches O(n²) when the list is already sorted and the pivot degenerates. The algorithm remains safe under re-entrancy because it allocates and frees its working stack inside each call.
 
 ## Randomization and reversal
-- `collections_shuffle` performs Fisher–Yates by swapping each element with a random index in `[0, i]`. Because swaps route through the list API, all list invariants remain intact.
-- `collections_reverse` swaps mirrored indices until they meet, producing an in-place reversal with O(n) swaps.
+`collections_shuffle` executes a Fisher–Yates shuffle by swapping each element with a random index in `[0, i]`. Because the operation routes through the list API, invariants from custom implementations remain intact. `collections_reverse` performs mirrored swaps until the indices meet, delivering an in-place reversal with linear-time cost.
 
 ## Search and copy helpers
-- `collections_binary_search` assumes the list is sorted according to the sorter’s comparator. It performs iterative binary search returning the matching index or −1. Runtime is O(log n) on array lists but degrades to O(n log n) for linked lists due to per-access traversal.
-- `collections_copy` iterates through the source list and inserts each element into the destination at the same index. The destination must already have adequate capacity or a compatible `insert` that grows storage on demand.
+`collections_binary_search` assumes the list is sorted according to the sorter’s comparator. It performs an iterative binary search that returns the matching index or −1. Array lists observe O(log n) runtime, while linked lists degrade to O(n log n) because each index access traverses nodes. `collections_copy` iterates through the source list and inserts each element into the destination at the same index. The destination must already expose an `insert` that grows storage on demand or have adequate capacity.
 
 ## Extremum calculations
-- `collections_min_max` scans the list in pairs, reducing comparator calls by comparing pair members first and then updating global min/max. Handles odd-length lists by checking the final element separately.
-- `collections_min` and `collections_max` run linear scans returning the extremal elements. All three functions return NULL for empty lists.
+`collections_min_max` scans the list in pairs, comparing members to reduce comparator calls before updating global minima and maxima. Odd-length lists handle the final element separately. `collections_min` and `collections_max` perform full linear scans and return NULL for empty lists, matching the behavior of the combined routine.


### PR DESCRIPTION
## Summary
- rewrite architecture overview into prose paragraphs suitable for wiki consumption
- convert container, matrix, simplex solver, and sorting docs into narrative sections without bullet lists

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690457b7cc18832dbfeeb2e3fcbfab33